### PR TITLE
Allow access to dig_tunnel for other mods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1161,3 +1161,5 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
+
+tunnelmaker.dig_tunnel = dig_tunnel


### PR DESCRIPTION
This allows other mods to use the dig_tunnel function, e. g. https://content.minetest.net/packages/rlars/railbuilder/